### PR TITLE
Fix pen down command macro

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3742,7 +3742,7 @@
   //#define MAIN_MENU_ITEM_1_CONFIRM          // Show a confirmation dialog before this action
 
   #define MAIN_MENU_ITEM_2_DESC "Pen Down " 
-  #define MAIN_MENU_ITEM_2_GCODE "M28 P0 S30 T50" 
+  #define MAIN_MENU_ITEM_2_GCODE "M280 P0 S30 T50" 
   //#define MAIN_MENU_ITEM_2_CONFIRM
 
   //#define MAIN_MENU_ITEM_3_DESC "Preheat for " PREHEAT_2_LABEL


### PR DESCRIPTION
Hi, 

I have found a typo in the macro to lower down the pen: a `0` is missing in the command.

I don't find the meaning of `T50` in the [documentation](https://marlinfw.org/docs/gcode/M280.html), what is it used for ?

Regards