### PR TITLE
Add CI for build fw

### DIFF
--- a/.github/workflows/makelangelo-fw.yml
+++ b/.github/workflows/makelangelo-fw.yml
@@ -1,0 +1,53 @@
+#
+# Build the firmware
+#
+
+name: FW
+
+on:
+  push:
+
+jobs:
+  build_fw:
+    name: Build firmware
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out the PR
+      uses: actions/checkout@v2
+
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Cache PlatformIO
+      uses: actions/cache@v2
+      with:
+        path: ~/.platformio
+        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+
+    - name: Select Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.7' # Version range or exact version of a Python version to use, using semvers version range syntax.
+        architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
+
+    - name: Install PlatformIO
+      run: |
+        pip install -U https://github.com/platformio/platformio-core/archive/develop.zip
+        platformio update
+
+    - name: Build
+      run: |
+        platformio run
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: firmware.hex
+        path: .pio/build/mega2560/firmware.hex
+        retention-days: 5


### PR DESCRIPTION
### Description

I have added a new CI workflow to be able to build the firmware with the underlying source.

### Benefits

The file `firmware.hex` is now accessible to anyone who has a github account in the github action tabs:
![image](https://user-images.githubusercontent.com/23615562/149936928-bd891e7f-30d9-492f-acb9-3d8be9f3394a.png)

It will help publishing the firmware to user without building it locally. 
Later, a nightly release could be created as in Makelangelo-software in order to publish firmware with more easy access to user.

Furthermore, when a user forks this repo, he will be able to compile it's own firmware easily on it's account.

Note: I didn't try this firmware as I do not have this hardware.

Another question: is this PR opened on the correct branch ?

WDYT ?